### PR TITLE
Fixed single argument update

### DIFF
--- a/http/src/main/scala/com/dslplatform/api/client/ClientPersistableRepository.scala
+++ b/http/src/main/scala/com/dslplatform/api/client/ClientPersistableRepository.scala
@@ -49,7 +49,7 @@ class ClientPersistableRepository[T <: AggregateRoot: ClassTag](locator: Service
     crudProxy.create(insert).map(_.URI)
 
   def update(updates: TraversableOnce[T]): Future[Unit] =
-    standardProxy.persist(Nil, updates.map { t => (t, t) }, Nil).map(_ => ())
+    standardProxy.persist(Nil, updates.map { t => (null.asInstanceOf[T], t) }, Nil).map(_ => ())
 
   def update(update: T): Future[Unit] =
     crudProxy.update(update).map(_ => ())

--- a/http/src/main/scala/com/dslplatform/api/client/HttpStandardProxy.scala
+++ b/http/src/main/scala/com/dslplatform/api/client/HttpStandardProxy.scala
@@ -43,7 +43,7 @@ class HttpStandardProxy(
 
   def update[TAggregate <: AggregateRoot: ClassTag](
       updates: TraversableOnce[TAggregate]): Future[Unit] =
-    persist(updates = updates.map(t => (t, t))).map(_ => ())
+    persist(updates = updates.map(t => (null.asInstanceOf[TAggregate], t))).map(_ => ())
 
   def delete[TAggregate <: AggregateRoot: ClassTag](
       deletes: TraversableOnce[TAggregate]): Future[Unit] =

--- a/http/src/test/scala/com/dslplatform/test/HistoryTest.scala
+++ b/http/src/test/scala/com/dslplatform/test/HistoryTest.scala
@@ -70,8 +70,6 @@ class HistoryTest extends Specification with Common {
       h3.snapshots(2).action === "DELETE"
       h3.snapshots(2).value.i === sr3.i
     }
-
-    true
   }
 
   def multipleCrudViaRepositories = { implicit locator: ServiceLocator =>


### PR DESCRIPTION
... to send (null, t) tuples instead (t, t) which was a noop.
